### PR TITLE
Parameterize ipmi lan channel

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ## Override these in host_vars or env to "arm" the ipmi setter
 get_ipmi: False
 set_ipmi: False
+lan_channel: 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,9 +10,11 @@
 #    - ipmi_watchdog
 - name: create directory for ansible custom facts
   file: state=directory recurse=yes path=/etc/ansible/facts.d
+
 - name: install custom impi fact
-  copy: src=ipmi.fact dest=/etc/ansible/facts.d mode=0755
+  template: src=ipmi.fact.j2 dest=/etc/ansible/facts.d/ipmi.fact mode=0755
   register: config_status
+
 - name: reread facts after adding custom fact
   setup: filter=ansible_local
   when: config_status|changed

--- a/templates/ipmi.fact.j2
+++ b/templates/ipmi.fact.j2
@@ -1,7 +1,7 @@
 #!/bin/bash
 #set -x
 
-channel=1
+channel={{ lan_channel }}
 
 echo "{"
 echo "  \"lan_$channel\": {"


### PR DESCRIPTION
Lan channel might not be 1 on all hosts, use it as a parameter (instead of trying to detect which channel to use in the facts script).
