### PR TITLE
Prevent shell expansion in ipmi.fact

### DIFF
--- a/templates/ipmi.fact.j2
+++ b/templates/ipmi.fact.j2
@@ -8,7 +8,7 @@ echo "  \"lan_$channel\": {"
 
 first_line=1
 ipmitool lan print $channel | tr -d ' ' | while read line; do
-  key=`echo $line | cut -d: -f 1 | tr -d '.' | tr -d [0-9] | tr '[:upper:]' '[:lower:]'`
+  key=`echo $line | cut -d: -f 1 | tr -d '.' | tr -d '[0-9]' | tr '[:upper:]' '[:lower:]'`
   if [ -n "$key" ]; then
     if [ $first_line -eq 1 ]; then
       first_line=0

--- a/templates/ipmi.fact.j2
+++ b/templates/ipmi.fact.j2
@@ -8,7 +8,7 @@ echo "  \"lan_$channel\": {"
 
 first_line=1
 ipmitool lan print $channel | tr -d ' ' | while read line; do
-  key=`echo $line | cut -d: -f 1 | tr -d '.' | tr -d '[0-9]' | tr '[:upper:]' '[:lower:]'`
+  key=`echo $line | cut -d: -f 1 | tr -d '0-9.' | tr '[:upper:]' '[:lower:]'`
   if [ -n "$key" ]; then
     if [ $first_line -eq 1 ]; then
       first_line=0


### PR DESCRIPTION
If the user of the module has files with names matching the [0-9] glob
in their home directory, then the glob is expanded by the shell and the
ipmi.fact script fails.

This patch uses quotation marks to prevent shell expansion of that
expression.